### PR TITLE
Allow more characters in file names

### DIFF
--- a/app/com/lucidchart/open/cashy/amazons3/Validation.scala
+++ b/app/com/lucidchart/open/cashy/amazons3/Validation.scala
@@ -1,0 +1,11 @@
+package com.lucidchart.open.cashy.amazons3
+
+object Validation {
+
+  // http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html
+  // plus @, for backwards compatibility
+  private val filenameRegex = """[0-9a-zA-Z!-_\.*'()@/]+""".r
+
+  def isSafeS3Key(key: String) = filenameRegex.unapplySeq(key).isDefined
+
+}


### PR DESCRIPTION
I wanted to upload 

![d'oh](http://blogs.telegraph.co.uk/news/files/2013/07/homer-simpson-doh.jpg)

Unfortunately, I couldn't name it d'oh.jpg, like I wanted ;)

The validation regex has been touched several times. Initially it was "Restrict asset name by valid html characters". I'm not really sure what "valid HTML characters" are (everything except `<>&`, or maybe everything except `<>&'"` ?), or the rationale for disallowing them.

Amazon has some suggestions for character limitations for S3 keys:

http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html

I'm not sure what's best, but it'd be nice if Cashy has a minimum of character limitations.