### PR TITLE
Make KrakenClient have explicit timeout and close connections

### DIFF
--- a/app/com/lucidchart/open/cashy/utils/KrakenClient.scala
+++ b/app/com/lucidchart/open/cashy/utils/KrakenClient.scala
@@ -23,6 +23,9 @@ class KrakenClient {
   protected val apiSecret = configuration.getString("kraken.apiSecret").get
   protected val uploadUrl = configuration.getString("kraken.imageUploadUrl").get
   protected val usageUrl = configuration.getString("kraken.usageUrl").get
+  protected val connectionRequestTimeout = configuration.getInt("kraken.connectionRequestTimeout").get
+  protected val connectTimeout = configuration.getInt("kraken.connectTimeout").get
+  protected val socketTimeout = configuration.getInt("kraken.socketTimeout").get
 
   /**
    * @param sourceUrl the string url of the image that will be resized
@@ -174,12 +177,10 @@ class KrakenClient {
   }
 
   private def getRequestConfig = {
-    val timeout = configuration.getInt("kraken.connectionTimeout").get
-    val CONNECTION_TIMEOUT_MS = timeout * 1000;
     RequestConfig.custom()
-      .setConnectionRequestTimeout(CONNECTION_TIMEOUT_MS)
-      .setConnectTimeout(CONNECTION_TIMEOUT_MS)
-      .setSocketTimeout(CONNECTION_TIMEOUT_MS)
+      .setConnectionRequestTimeout(connectionRequestTimeout)
+      .setConnectTimeout(connectTimeout)
+      .setSocketTimeout(socketTimeout)
       .build()
   }
 

--- a/app/com/lucidchart/open/cashy/utils/KrakenClient.scala
+++ b/app/com/lucidchart/open/cashy/utils/KrakenClient.scala
@@ -23,9 +23,9 @@ class KrakenClient {
   protected val apiSecret = configuration.getString("kraken.apiSecret").get
   protected val uploadUrl = configuration.getString("kraken.imageUploadUrl").get
   protected val usageUrl = configuration.getString("kraken.usageUrl").get
-  protected val connectionRequestTimeout = configuration.getInt("kraken.connectionRequestTimeout").get
-  protected val connectTimeout = configuration.getInt("kraken.connectTimeout").get
-  protected val socketTimeout = configuration.getInt("kraken.socketTimeout").get
+  protected val connectionRequestTimeout = configuration.getInt("kraken.connectionRequestTimeoutMs").get
+  protected val connectTimeout = configuration.getInt("kraken.connectTimeoutMs").get
+  protected val socketTimeout = configuration.getInt("kraken.socketTimeoutMs").get
 
   /**
    * @param sourceUrl the string url of the image that will be resized

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -137,7 +137,9 @@ kraken.usageUrl = "https://api.kraken.io/user_status"
 kraken.usageAlertThreshold = .9
 kraken.apiKey = ""
 kraken.apiSecret = ""
-kraken.connectionTimeout = 120
+kraken.connectionRequestTimeout = 120000
+kraken.connectTimeout = 120000
+kraken.socketTimeout = 120000
 
 upload.minNestedDirectories = 2
 upload.extensions = ["js", "css", "jpg", "jpeg", "png", "gif", "txt", "csv"]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -17,19 +17,19 @@ application.langs="en"
 # Default to Global in the root package.
 application.global="com.lucidchart.open.cashy.Global"
 
-# Router 
+# Router
 # ~~~~~
 # Define the Router object to use for this application.
 # This router will be looked up first when the application is starting up,
-# so make sure this is the entry point. 
-# Furthermore, it's assumed your route file is named properly. 
+# so make sure this is the entry point.
+# Furthermore, it's assumed your route file is named properly.
 # So for an application router like `my.application.Router`,
 # you may need to define a router file `conf/my.application.routes`.
 # Default to Routes in the root package (and conf/routes)
 # application.router=my.application.Routes
 
 # Database configuration
-# ~~~~~ 
+# ~~~~~
 # You can declare as many datasources as you want.
 # By convention, the default datasource is named `default`
 #
@@ -137,9 +137,9 @@ kraken.usageUrl = "https://api.kraken.io/user_status"
 kraken.usageAlertThreshold = .9
 kraken.apiKey = ""
 kraken.apiSecret = ""
-kraken.connectionRequestTimeout = 120000
-kraken.connectTimeout = 120000
-kraken.socketTimeout = 120000
+kraken.connectionRequestTimeoutMs = 120000
+kraken.connectTimeoutMs = 120000
+kraken.socketTimeoutMs = 120000
 
 upload.minNestedDirectories = 2
 upload.extensions = ["js", "css", "jpg", "jpeg", "png", "gif", "txt", "csv"]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -137,9 +137,9 @@ kraken.usageUrl = "https://api.kraken.io/user_status"
 kraken.usageAlertThreshold = .9
 kraken.apiKey = ""
 kraken.apiSecret = ""
-kraken.connectionRequestTimeoutMs = 120000
-kraken.connectTimeoutMs = 120000
-kraken.socketTimeoutMs = 120000
+kraken.connectionRequestTimeoutMs = 1000
+kraken.connectTimeoutMs = 100
+kraken.socketTimeoutMs = 60000
 
 upload.minNestedDirectories = 2
 upload.extensions = ["js", "css", "jpg", "jpeg", "png", "gif", "txt", "csv"]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -137,6 +137,7 @@ kraken.usageUrl = "https://api.kraken.io/user_status"
 kraken.usageAlertThreshold = .9
 kraken.apiKey = ""
 kraken.apiSecret = ""
+kraken.connectionTimeout = 120
 
 upload.minNestedDirectories = 2
 upload.extensions = ["js", "css", "jpg", "jpeg", "png", "gif", "txt", "csv"]


### PR DESCRIPTION
PROD-870

Documentation: http://hc.apache.org/httpcomponents-client-ga/tutorial/html/fundamentals.html#d5e145
Closing the Response isn't necessary if you close the `InputStream` from `getContent`; however, `Source.fromInputStream` does not do that. (With the stated reason being that an InputStream could receive more data)

In addition, I've added an explicit config value for timing out the requests. By default, this should be the system default (not infinite). (https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/config/RequestConfig.html#getSocketTimeout%28%29)

Exceptions thrown (Timeout Exceptions, etc...) already are displayed to the client after submitting the form.