### PR TITLE
Added webp to the list of supported image types

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -142,10 +142,10 @@ kraken.connectTimeoutMs = 100
 kraken.socketTimeoutMs = 60000
 
 upload.minNestedDirectories = 2
-upload.extensions = ["js", "css", "jpg", "jpeg", "png", "gif", "txt", "csv"]
+upload.extensions = ["js", "css", "jpg", "jpeg", "png", "gif", "webp", "txt", "csv"]
 upload.jsExtensions = ["js"]
 upload.cssExtensions = ["css"]
-upload.imageExtensions = ["jpg", "jpeg", "png", "gif"]
+upload.imageExtensions = ["jpg", "jpeg", "png", "gif", "webp"]
 upload.minGzipSavings = .2
 upload.jsCompression.enabled = true
 upload.cssCompression.enabled = true


### PR DESCRIPTION
Cashy currently does not support uploading webp images, so this should fix that.