### PR TITLE
Remove references to cloudfront

### DIFF
--- a/app/com/lucidchart/open/cashy/amazons3/S3Client.scala
+++ b/app/com/lucidchart/open/cashy/amazons3/S3Client.scala
@@ -32,8 +32,8 @@ case class AssetMetadata(
 )
 
 class S3Client @Inject() (
-  buckets: Buckets,
-  configuration: Configuration
+    buckets: Buckets,
+    configuration: Configuration
 ) {
   val logger = Logger(this.getClass)
 
@@ -52,12 +52,15 @@ class S3Client @Inject() (
 
   private def headObject(bucketName: String, key: String): Option[HeadObjectResponse] = {
     try {
-      Some(s3Client.headObject(
-        HeadObjectRequest.builder()
-          .bucket(buckets.bucketNameForSDK(bucketName))
-          .key(key)
-          .build()
-      ))
+      Some(
+        s3Client.headObject(
+          HeadObjectRequest
+            .builder()
+            .bucket(buckets.bucketNameForSDK(bucketName))
+            .key(key)
+            .build()
+        )
+      )
     } catch {
       case _: NoSuchKeyException => None
     }
@@ -126,7 +129,9 @@ class S3Client @Inject() (
   def removeFromS3(bucketName: String, assetName: String, gzipped: Boolean = false): Unit = {
     val objectName = if (gzipped) assetName + ".gz" else assetName
     try {
-      s3Client.deleteObject(DeleteObjectRequest.builder().bucket(buckets.bucketNameForSDK(bucketName)).key(assetName).build())
+      s3Client.deleteObject(
+        DeleteObjectRequest.builder().bucket(buckets.bucketNameForSDK(bucketName)).key(assetName).build()
+      )
     } catch {
       case e: Exception => {
         logger.error(s"Error when deleting asset $bucketName/$objectName")

--- a/app/com/lucidchart/open/cashy/amazons3/S3Sync.scala
+++ b/app/com/lucidchart/open/cashy/amazons3/S3Sync.scala
@@ -95,7 +95,7 @@ class S3Sync @Inject() (
         syncUserId,
         bucket,
         s3Asset.key,
-        buckets.cloudfrontUrl(bucket) + s3Asset.key,
+        buckets.publicUrl(bucket) + s3Asset.key,
         hasGzip,
       )
     }

--- a/app/com/lucidchart/open/cashy/amazons3/S3Sync.scala
+++ b/app/com/lucidchart/open/cashy/amazons3/S3Sync.scala
@@ -95,7 +95,7 @@ class S3Sync @Inject() (
         syncUserId,
         bucket,
         s3Asset.key,
-        buckets.cloudfrontUrl(bucket) + s3Asset.key,
+        buckets.publicUrl(bucket) + s3Asset.key,
         hasGzip
       )
     }

--- a/app/com/lucidchart/open/cashy/config/Buckets.scala
+++ b/app/com/lucidchart/open/cashy/config/Buckets.scala
@@ -3,18 +3,17 @@ package com.lucidchart.open.cashy.config
 import javax.inject.Inject
 import play.api.Configuration
 
-class Buckets(bucketCloudfrontMap: Map[String, String]) {
+class Buckets(bucketUrlMap: Map[String, String]) {
   @Inject()
   def this(configuration: Configuration) =
     this(
       configuration
-        .get[Map[String, Configuration]]("amazon.s3.bucketCloudfrontMap")
-        .map { case (k, c) => (k -> c.get[String]("cloudfront")) }
+        .get[Map[String, String]]("amazon.s3.bucketUrlMap")
     )
 
-  def names = bucketCloudfrontMap.keySet
+  def names = bucketUrlMap.keySet
 
-  def cloudfrontUrl(bucket: String): String = bucketCloudfrontMap(bucket)
+  def publicUrl(bucket: String): String = bucketUrlMap(bucket)
 
-  def contains(name: String): Boolean = bucketCloudfrontMap.contains(name)
+  def contains(name: String): Boolean = bucketUrlMap.contains(name)
 }

--- a/app/com/lucidchart/open/cashy/config/Buckets.scala
+++ b/app/com/lucidchart/open/cashy/config/Buckets.scala
@@ -3,19 +3,29 @@ package com.lucidchart.open.cashy.config
 import javax.inject.Inject
 import play.api.Configuration
 
-case class BucketConfig(cloudfrontId: String, bucketName: Option[String] = None)
+case class BucketConfig(publicUrl: String, bucketName: Option[String] = None)
 
 class Buckets(bucketConfigs: Map[String, BucketConfig]) {
   @Inject()
-  def this(configuration: Configuration) = this(
-    configuration.get[Map[String, Configuration]]("amazon.s3.bucketCloudfrontMap").map {
-      case (name, c) => name -> BucketConfig(c.get[String]("cloudfront"), c.getOptional[String]("bucketName"))
-    }
-  )
+  def this(configuration: Configuration) =
+    this(
+      configuration
+        .getOptional[Map[String, Configuration]]("buckets")
+        .map(_.map {
+          case (name, c) => name -> BucketConfig(c.get[String]("publicUrl"), c.getOptional[String]("bucketName"))
+        })
+        // Fall back to bucketCloudfrontMap for backwards compatibility
+        .getOrElse(
+          configuration.get[Map[String, Configuration]]("amazon.s3.bucketCloudfrontMap").map {
+            case (name, c) =>
+              name -> BucketConfig(c.get[String]("cloudfront"), c.getOptional[String]("bucketName"))
+          }
+        )
+    )
 
   def names = bucketConfigs.keySet
 
-  def cloudfrontUrl(bucket: String): String = bucketConfigs(bucket).cloudfrontId
+  def publicUrl(bucket: String): String = bucketConfigs(bucket).publicUrl
 
   def contains(name: String): Boolean = bucketConfigs.contains(name)
 

--- a/app/com/lucidchart/open/cashy/controllers/BrowseController.scala
+++ b/app/com/lucidchart/open/cashy/controllers/BrowseController.scala
@@ -73,7 +73,7 @@ class BrowseController @Inject() (
               BrowseItemType.asset,
               a,
               getItemName(a, BrowseItemType.asset),
-              buckets.cloudfrontUrl(bucket) + a,
+              buckets.publicUrl(bucket) + a,
               assets.get(a).map(_.hidden).getOrElse(false)
             )
           )
@@ -132,7 +132,7 @@ class BrowseController @Inject() (
           contentLength,
           contentType,
           fullS3AccessUrl + bucket + "/" + key,
-          buckets.cloudfrontUrl(bucket) + key,
+          buckets.publicUrl(bucket) + key,
           email,
           cacheControl,
           eTag,

--- a/app/com/lucidchart/open/cashy/controllers/BrowseController.scala
+++ b/app/com/lucidchart/open/cashy/controllers/BrowseController.scala
@@ -68,7 +68,7 @@ class BrowseController @Inject() (
               BrowseItemType.asset,
               a,
               getItemName(a, BrowseItemType.asset),
-              buckets.cloudfrontUrl(bucket) + a,
+              buckets.publicUrl(bucket) + a,
               assets.get(a).map(_.hidden).getOrElse(false)
             )
           )
@@ -126,7 +126,7 @@ class BrowseController @Inject() (
           created,
           contentLength,
           contentType,
-          buckets.cloudfrontUrl(bucket) + key,
+          buckets.publicUrl(bucket) + key,
           email,
           cacheControl,
           eTag,

--- a/app/com/lucidchart/open/cashy/models/AssetModel.scala
+++ b/app/com/lucidchart/open/cashy/models/AssetModel.scala
@@ -27,7 +27,7 @@ class AssetModel @Inject() (buckets: Buckets, configuration: Configuration, db: 
     val bucket = row.string("bucket")
     val key = row.string("key")
     Asset(
-      buckets.cloudfrontUrl(bucket) + key,
+      buckets.publicUrl(bucket) + key,
       bucket,
       key,
       row.long("user_id"),

--- a/app/com/lucidchart/open/cashy/models/AuditModel.scala
+++ b/app/com/lucidchart/open/cashy/models/AuditModel.scala
@@ -24,18 +24,18 @@ case class AuditEntry(
 case class AssetAuditData(
     bucket: String,
     assetKey: String,
-    cloudfrontUrl: String,
+    url: String,
     gzipped: Boolean
 )
 object AssetAuditData {
   implicit val uploadDataReads: Reads[AssetAuditData] = ((JsPath \ "bucket").read[String] and
     (JsPath \ "assetKey").read[String] and
-    (JsPath \ "cloudfrontUrl").read[String] and
+    (JsPath \ "url").read[String] and
     (JsPath \ "gzipped").read[Boolean])(AssetAuditData.apply _)
 
   implicit val uploadDataWrites: Writes[AssetAuditData] = ((JsPath \ "bucket").write[String] and
     (JsPath \ "assetKey").write[String] and
-    (JsPath \ "cloudfrontUrl").write[String] and
+    (JsPath \ "url").write[String] and
     (JsPath \ "gzipped").write[Boolean])(unlift(AssetAuditData.unapply))
 }
 
@@ -93,10 +93,10 @@ class AuditModel @Inject() (userModel: UserModel, configuration: Configuration, 
       userId: Long,
       bucket: String,
       assetKey: String,
-      cloudfrontUrl: String,
+      url: String,
       gzipped: Boolean
   ): Unit = {
-    val uploadData = Json.stringify(Json.toJson(AssetAuditData(bucket, assetKey, cloudfrontUrl, gzipped)))
+    val uploadData = Json.stringify(Json.toJson(AssetAuditData(bucket, assetKey, url, gzipped)))
     createAuditEntry(userId, uploadData, AuditType.upload)
   }
 
@@ -104,10 +104,10 @@ class AuditModel @Inject() (userModel: UserModel, configuration: Configuration, 
       userId: Long,
       bucket: String,
       assetKey: String,
-      cloudfrontUrl: String,
+      url: String,
       gzipped: Boolean
   ): Unit = {
-    val deleteData = Json.stringify(Json.toJson(AssetAuditData(bucket, assetKey, cloudfrontUrl, gzipped)))
+    val deleteData = Json.stringify(Json.toJson(AssetAuditData(bucket, assetKey, url, gzipped)))
     createAuditEntry(userId, deleteData, AuditType.delete)
   }
 

--- a/app/com/lucidchart/open/cashy/models/BrowseItem.scala
+++ b/app/com/lucidchart/open/cashy/models/BrowseItem.scala
@@ -16,7 +16,7 @@ case class BrowseItemDetail(
     size: String,
     contentType: String,
     s3Url: String,
-    cloudfrontUrl: String,
+    url: String,
     creator: String,
     cacheControl: String,
     eTag: String,
@@ -31,7 +31,7 @@ object BrowseItemDetail {
       (JsPath \ "size").write[String] and
       (JsPath \ "contentType").write[String] and
       (JsPath \ "s3Url").write[String] and
-      (JsPath \ "cloudfrontUrl").write[String] and
+      (JsPath \ "url").write[String] and
       (JsPath \ "creator").write[String] and
       (JsPath \ "cacheControl").write[String] and
       (JsPath \ "eTag").write[String] and

--- a/app/com/lucidchart/open/cashy/models/BrowseItem.scala
+++ b/app/com/lucidchart/open/cashy/models/BrowseItem.scala
@@ -15,7 +15,7 @@ case class BrowseItemDetail(
     creationDate: String,
     size: String,
     contentType: String,
-    cloudfrontUrl: String,
+    url: String,
     creator: String,
     cacheControl: String,
     eTag: String,
@@ -29,7 +29,7 @@ object BrowseItemDetail {
       (JsPath \ "creationDate").write[String] and
       (JsPath \ "size").write[String] and
       (JsPath \ "contentType").write[String] and
-      (JsPath \ "cloudfrontUrl").write[String] and
+      (JsPath \ "url").write[String] and
       (JsPath \ "creator").write[String] and
       (JsPath \ "cacheControl").write[String] and
       (JsPath \ "eTag").write[String] and

--- a/app/com/lucidchart/open/cashy/views/audit/index.scala.html
+++ b/app/com/lucidchart/open/cashy/views/audit/index.scala.html
@@ -37,7 +37,7 @@
               }
             </div>
             <br />
-            <div><a href="@audit.data.cloudfrontUrl">@audit.data.cloudfrontUrl</a></div>
+            <div><a href="@audit.data.url">@audit.data.url</a></div>
           </td>
           <td>@audit.created</td>
         </tr>

--- a/app/com/lucidchart/open/cashy/views/helpers/assetDetails.scala.html
+++ b/app/com/lucidchart/open/cashy/views/helpers/assetDetails.scala.html
@@ -18,7 +18,7 @@
           <div class="item-detail-label">S3 Key</div><div class="item-detail-value" id="@bucketName-itemKey"></div>
         </div>
         <div>
-          <div class="item-detail-label">Cloudfront Url</div><div class="item-detail-value"><a id="@bucketName-itemCloudrontUrl" href="" target="_blank"></a></div>
+          <div class="item-detail-label">Published Url</div><div class="item-detail-value"><a id="@bucketName-itemCloudrontUrl" href="" target="_blank"></a></div>
         </div>
         <div>
           <div class="item-detail-label">Created At</div><div class="item-detail-value" id="@bucketName-itemCreatedAt"></div>
@@ -64,7 +64,7 @@
         $('#@bucketName-itemName').text(data.name);
         $('#@bucketName-itemKey').text(data.key);
         $('#@bucketName-itemS3Url').text(data.s3Url).attr('href', data.s3Url);
-        $('#@bucketName-itemCloudrontUrl').text(data.cloudfrontUrl).attr('href', data.cloudfrontUrl);
+        $('#@bucketName-itemCloudrontUrl').text(data.url).attr('href', data.url);
         $('#@bucketName-itemCreatedAt').text(data.creationDate);
         $('#@bucketName-itemCreatedBy').text(data.creator);
         $('#@bucketName-itemETag').text(data.eTag);
@@ -74,7 +74,7 @@
         $('#@bucketName-itemGzipped').text(data.gzipped);
 
         var uploadUrl = "@cashyRoutes.UploadController.index(Some(bucketName))";
-        uploadUrl += "&path=" + data.key.substring(0,data.key.lastIndexOf("/")+1) + "&assetURL=" + data.cloudfrontUrl
+        uploadUrl += "&path=" + data.key.substring(0,data.key.lastIndexOf("/")+1) + "&assetURL=" + data.url
 
         $('#@bucketName-itemUploadAnotherVersion').attr('href', uploadUrl);
 
@@ -95,7 +95,7 @@
     $('#@bucketName-itemS3Url').show();
     $('a.show-s3-url').hide();
   });
-</script> 
+</script>
 
 <style>
   #@bucketName-itemName {

--- a/app/com/lucidchart/open/cashy/views/helpers/assetDetails.scala.html
+++ b/app/com/lucidchart/open/cashy/views/helpers/assetDetails.scala.html
@@ -18,7 +18,7 @@
           <div class="item-detail-label">S3 Key</div><div class="item-detail-value" id="@bucketName-itemKey"></div>
         </div>
         <div>
-          <div class="item-detail-label">Cloudfront Url</div><div class="item-detail-value"><a id="@bucketName-itemCloudrontUrl" href="" target="_blank"></a></div>
+          <div class="item-detail-label">Published Url</div><div class="item-detail-value"><a id="@bucketName-itemUrl" href="" target="_blank"></a></div>
         </div>
         <div>
           <div class="item-detail-label">Created At</div><div class="item-detail-value" id="@bucketName-itemCreatedAt"></div>
@@ -60,7 +60,7 @@
       success: function(data) {
         $('#@bucketName-itemName').text(data.name);
         $('#@bucketName-itemKey').text(data.key);
-        $('#@bucketName-itemCloudrontUrl').text(data.cloudfrontUrl).attr('href', data.cloudfrontUrl);
+        $('#@bucketName-itemUrl').text(data.url).attr('href', data.url);
         $('#@bucketName-itemCreatedAt').text(data.creationDate);
         $('#@bucketName-itemCreatedBy').text(data.creator);
         $('#@bucketName-itemETag').text(data.eTag);
@@ -70,7 +70,7 @@
         $('#@bucketName-itemGzipped').text(data.gzipped);
 
         var uploadUrl = "@cashyRoutes.UploadController.index(Some(bucketName))";
-        uploadUrl += "&path=" + data.key.substring(0,data.key.lastIndexOf("/")+1) + "&assetURL=" + data.cloudfrontUrl
+        uploadUrl += "&path=" + data.key.substring(0,data.key.lastIndexOf("/")+1) + "&assetURL=" + data.url
 
         $('#@bucketName-itemUploadAnotherVersion').attr('href', uploadUrl);
 
@@ -82,7 +82,7 @@
     })
 
   });
-</script> 
+</script>
 
 <style>
   #@bucketName-itemName {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -113,10 +113,12 @@ auth.google.domainWhitelist = ["lucidchart.com"]
 # You can configure a non-default credentials file to load AWS credentials from
 # aws.credentialsFile = /etc/aws/dev-credentials
 amazon.s3.enabled = true
-amazon.s3.bucketCloudfrontMap = {}
+amazon.s3.bucketUrlMap = {}
 # Example:
-# (this particular example won't work as this bucket and distribution don't exist
-# amazon.s3.bucketCloudfrontMap.dev-cashy.cloudfront =  "http://d2zt0093sgpvii.cloudfront.net/"
+# This would map the "example" bucket to https://example.com/ (which could
+# point to  a CDN such as cloudfront, or a proxy in front of s3):
+#
+# amazon.s3.bucketUrlMap.example =  "https://example.com/"
 amazon.s3.fullAccessUrl = "https://s3.amazonaws.com/"
 amazon.s3.cdn.version = "1"
 amazon.s3.upload.timeout = 30

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -113,16 +113,23 @@ auth.google.domainWhitelist = ["lucidchart.com"]
 # You can configure a non-default credentials file to load AWS credentials from
 # aws.credentialsFile = /etc/aws/dev-credentials
 amazon.s3.enabled = true
-amazon.s3.bucketCloudfrontMap = {}
-# Example:
-# (this particular example won't work as this bucket and distribution don't exist
-# amazon.s3.bucketCloudfrontMap.dev-cashy.cloudfront =  "http://d2zt0093sgpvii.cloudfront.net/"
+amazon.s3.bucketUrlMap = {}
 amazon.s3.cdn.version = "1"
 amazon.s3.upload.timeout = 30
 amazon.s3.upload.cachetime = 2592000
 amazon.s3.listing.maxKeys = 100
 amazon.s3.syncFrequency = 86400
 amazon.s3.tempUploadPrefix = ".cashy"
+
+# Example:
+# This would map the "example" bucket to https://example.com/ (which could
+# point to  a CDN such as cloudfront, or a proxy in front of s3):
+#
+#   buckets.example.publicUrl =  "https://example.com/"
+#
+# And this would use an access point for the example bucket:
+#
+#   buckets.example.bucketName = "arn:aws:s3:us-east-1:123456789012:accesspoint/example"
 
 upload.minNestedDirectories = 2
 upload.extensions = [


### PR DESCRIPTION
Cashy works fine if you put something other than cloudfront in front of S3 (like cloudflare, akamai, fastly, haproxy, nginx, apache, etc.) so use more general language for the published url.