### PR TITLE
Require access point configuration for s3 buckets

### DIFF
--- a/app/com/lucidchart/open/cashy/amazons3/S3Client.scala
+++ b/app/com/lucidchart/open/cashy/amazons3/S3Client.scala
@@ -16,6 +16,7 @@ import software.amazon.awssdk.profiles.ProfileFile
 import software.amazon.awssdk.services.s3.model._
 import software.amazon.awssdk.services.s3.{S3Client => AmazonS3Client}
 import software.amazon.awssdk.core.sync.RequestBody
+import com.lucidchart.open.cashy.config.Buckets
 
 case class ListObjectsResponse(
     folders: List[String],
@@ -23,25 +24,53 @@ case class ListObjectsResponse(
     nextMarker: Option[String]
 )
 
-class S3Client @Inject() (configuration: Configuration) {
+case class AssetMetadata(
+    eTag: Option[String],
+    contentLength: Option[Long],
+    cacheControl: Option[String],
+    contentType: Option[String]
+)
+
+class S3Client @Inject() (
+  buckets: Buckets,
+  configuration: Configuration
+) {
   val logger = Logger(this.getClass)
 
   protected val uploadTimeout = configuration.get[Int]("amazon.s3.upload.timeout")
   protected val uploadCacheTime = configuration.get[Int]("amazon.s3.upload.cachetime")
   protected val listingMaxKeys = configuration.get[Int]("amazon.s3.listing.maxKeys")
   protected val tempUploadPrefix = configuration.get[String]("amazon.s3.tempUploadPrefix")
-  protected val s3AccessUrl = configuration.get[String]("amazon.s3.fullAccessUrl")
   private val credentialsFile = configuration.getOptional[String]("aws.credentialsFile")
 
   protected val awsCredentialsProvider = getAwsCredentialsProvider()
   protected val s3Client = AmazonS3Client.builder().credentialsProvider(awsCredentialsProvider).build()
 
   def existsInS3(bucketName: String, objectName: String): Boolean = {
+    headObject(bucketName, objectName).isDefined
+  }
+
+  private def headObject(bucketName: String, key: String): Option[HeadObjectResponse] = {
     try {
-      s3Client.headObject(HeadObjectRequest.builder().bucket(bucketName).key(objectName).build())
-      true
+      Some(s3Client.headObject(
+        HeadObjectRequest.builder()
+          .bucket(buckets.bucketNameForSDK(bucketName))
+          .key(key)
+          .build()
+      ))
     } catch {
-      case e: NoSuchKeyException => false
+      case _: NoSuchKeyException => None
+    }
+  }
+
+  def getAssetMetadata(bucketName: String, key: String): Option[AssetMetadata] = {
+    headObject(bucketName, key).map { h =>
+      AssetMetadata(
+        Option(h.eTag()).map(_.replaceAll("^\"|\"$", "")),
+        Option(h.contentLength()).map(_.longValue),
+        Option(h.cacheControl()),
+        Option(h.contentType())
+      )
     }
   }
 
@@ -50,7 +79,7 @@ class S3Client @Inject() (configuration: Configuration) {
       s3Client.putObject(
         PutObjectRequest
           .builder()
-          .bucket(bucketName)
+          .bucket(buckets.bucketNameForSDK(bucketName))
           .key(key)
           .build(),
         RequestBody.fromBytes(Array(0))
@@ -74,7 +103,7 @@ class S3Client @Inject() (configuration: Configuration) {
 
     val requestBuilder = PutObjectRequest
       .builder()
-      .bucket(bucketName)
+      .bucket(buckets.bucketNameForSDK(bucketName))
       .key(objectName)
       .contentLength(bytes.length)
       .cacheControl(s"public, no-transform, max-age=${uploadCacheTime}")
@@ -94,22 +123,10 @@ class S3Client @Inject() (configuration: Configuration) {
     }
   }
 
-  // Uploads a file to the temp directory in S3 and returns the full amazon s3 url for it
-  def uploadTempFile(
-      bucketName: String,
-      assetName: String,
-      bytes: Array[Byte],
-      contentType: Option[String]
-  ): String = {
-    val tempName = tempUploadPrefix + "/" + assetName
-    uploadToS3(bucketName, tempName, bytes, contentType, false)
-    s3AccessUrl + bucketName + "/" + tempName
-  }
-
   def removeFromS3(bucketName: String, assetName: String, gzipped: Boolean = false): Unit = {
     val objectName = if (gzipped) assetName + ".gz" else assetName
     try {
-      s3Client.deleteObject(DeleteObjectRequest.builder().bucket(bucketName).key(assetName).build())
+      s3Client.deleteObject(DeleteObjectRequest.builder().bucket(buckets.bucketNameForSDK(bucketName)).key(assetName).build())
     } catch {
       case e: Exception => {
         logger.error(s"Error when deleting asset $bucketName/$objectName")
@@ -121,7 +138,7 @@ class S3Client @Inject() (configuration: Configuration) {
   def listObjects(bucketName: String, prefix: String, marker: Option[String] = None): ListObjectsResponse = {
     val requestBuilder = ListObjectsV2Request
       .builder()
-      .bucket(bucketName)
+      .bucket(buckets.bucketNameForSDK(bucketName))
       .prefix(prefix)
       .delimiter("/")
       .maxKeys(listingMaxKeys)
@@ -149,7 +166,7 @@ class S3Client @Inject() (configuration: Configuration) {
   }
 
   def listAllObjects(bucketName: String): Iterator[S3SyncAsset] = {
-    val listRequest = ListObjectsV2Request.builder().bucket(bucketName).build()
+    val listRequest = ListObjectsV2Request.builder().bucket(buckets.bucketNameForSDK(bucketName)).build()
 
     try {
       val objectListings = s3Client.listObjectsV2Paginator(listRequest)

--- a/app/com/lucidchart/open/cashy/config/Buckets.scala
+++ b/app/com/lucidchart/open/cashy/config/Buckets.scala
@@ -3,18 +3,21 @@ package com.lucidchart.open.cashy.config
 import javax.inject.Inject
 import play.api.Configuration
 
-class Buckets(bucketCloudfrontMap: Map[String, String]) {
+case class BucketConfig(cloudfrontId: String, bucketName: Option[String] = None)
+
+class Buckets(bucketConfigs: Map[String, BucketConfig]) {
   @Inject()
-  def this(configuration: Configuration) =
-    this(
-      configuration
-        .get[Map[String, Configuration]]("amazon.s3.bucketCloudfrontMap")
-        .map { case (k, c) => (k -> c.get[String]("cloudfront")) }
-    )
+  def this(configuration: Configuration) = this(
+    configuration.get[Map[String, Configuration]]("amazon.s3.bucketCloudfrontMap").map {
+      case (name, c) => name -> BucketConfig(c.get[String]("cloudfront"), c.getOptional[String]("bucketName"))
+    }
+  )
 
-  def names = bucketCloudfrontMap.keySet
+  def names = bucketConfigs.keySet
 
-  def cloudfrontUrl(bucket: String): String = bucketCloudfrontMap(bucket)
+  def cloudfrontUrl(bucket: String): String = bucketConfigs(bucket).cloudfrontId
 
-  def contains(name: String): Boolean = bucketCloudfrontMap.contains(name)
+  def contains(name: String): Boolean = bucketConfigs.contains(name)
+
+  def bucketNameForSDK(bucket: String): String = bucketConfigs(bucket).bucketName.getOrElse(bucket)
 }

--- a/app/com/lucidchart/open/cashy/controllers/BrowseController.scala
+++ b/app/com/lucidchart/open/cashy/controllers/BrowseController.scala
@@ -20,9 +20,6 @@ import play.api.mvc.{Request, Action, ControllerComponents, AbstractController}
 import play.api.libs.json.Json
 import play.api.i18n.I18nSupport
 import play.api.Configuration
-import org.apache.http.client.methods.HttpHead
-import org.apache.http.impl.client.HttpClientBuilder
-import scala.io.Source
 
 class BrowseController @Inject() (
     authAction: AuthAction,
@@ -37,8 +34,6 @@ class BrowseController @Inject() (
     with I18nSupport {
 
   val logger = Logger(this.getClass)
-
-  val fullS3AccessUrl = configuration.get[String]("amazon.s3.fullAccessUrl")
 
   /**
     * Browse page, authentication required
@@ -118,11 +113,11 @@ class BrowseController @Inject() (
           case None => "???"
         }
         val created = cashyAsset.map(_.created).getOrElse("???").toString
-        val headers = getAssetHeaders(bucket, key)
-        val eTag = Option(headers.get("ETag").replaceAll("^\"|\"$", "")).getOrElse("???")
-        val contentLength = Option(headers.get("Content-Length")).getOrElse("???")
-        val cacheControl = Option(headers.get("Cache-Control")).getOrElse("???")
-        val contentType = Option(headers.get("Content-Type")).getOrElse("???")
+        val metadata = s3Client.getAssetMetadata(bucket, key)
+        val eTag = metadata.flatMap(_.eTag).getOrElse("???")
+        val contentLength = metadata.flatMap(_.contentLength).map(_.toString).getOrElse("???")
+        val cacheControl = metadata.flatMap(_.cacheControl).getOrElse("???")
+        val contentType = metadata.flatMap(_.contentType).getOrElse("???")
         val gzipped = s3Client.existsInS3(bucket, key + ".gz")
 
         val item = BrowseItemDetail(
@@ -131,7 +126,6 @@ class BrowseController @Inject() (
           created,
           contentLength,
           contentType,
-          fullS3AccessUrl + bucket + "/" + key,
           buckets.cloudfrontUrl(bucket) + key,
           email,
           cacheControl,
@@ -252,24 +246,4 @@ class BrowseController @Inject() (
       }
     }
   }
-
-  /**
-    * Make a HEAD request to a publicly exposed asset to get information
-    */
-  private def getAssetHeaders(bucket: String, key: String): Option[Map[String, String]] = {
-    val s3Url = fullS3AccessUrl + bucket + "/" + key
-
-    val httpClient = HttpClientBuilder.create().build()
-    val response = httpClient.execute(new HttpHead(s3Url))
-
-    // Get the headers
-    val headerMapOption = if (response.getStatusLine().getStatusCode() != 200) {
-      None
-    } else {
-      val headerMap = response.getAllHeaders().map(header => (header.getName() -> header.getValue())).toMap
-      Some(headerMap)
-    }
-    headerMapOption
-  }
-
 }

--- a/app/com/lucidchart/open/cashy/models/BrowseItem.scala
+++ b/app/com/lucidchart/open/cashy/models/BrowseItem.scala
@@ -15,7 +15,6 @@ case class BrowseItemDetail(
     creationDate: String,
     size: String,
     contentType: String,
-    s3Url: String,
     cloudfrontUrl: String,
     creator: String,
     cacheControl: String,
@@ -30,7 +29,6 @@ object BrowseItemDetail {
       (JsPath \ "creationDate").write[String] and
       (JsPath \ "size").write[String] and
       (JsPath \ "contentType").write[String] and
-      (JsPath \ "s3Url").write[String] and
       (JsPath \ "cloudfrontUrl").write[String] and
       (JsPath \ "creator").write[String] and
       (JsPath \ "cacheControl").write[String] and

--- a/app/com/lucidchart/open/cashy/views/helpers/assetDetails.scala.html
+++ b/app/com/lucidchart/open/cashy/views/helpers/assetDetails.scala.html
@@ -42,9 +42,6 @@
           <div class="item-detail-label">Gzipped</div><div class="item-detail-value" id="@bucketName-itemGzipped"></div>
         </div>
         <div>
-          <div class="item-detail-label">S3 Url</div><div class="item-detail-value"><a class="show-s3-url" href="" target="_blank">Click to show</a><a id="@bucketName-itemS3Url" href="" target="_blank"></a></div>
-        </div>
-        <div>
           <div class="item-detail-label">Upload Again</div><div class="item-detail-value"><a id="@bucketName-itemUploadAnotherVersion" href="" target="_blank">Click to upload another version</a></div>
         </div><br />
       </div>
@@ -63,7 +60,6 @@
       success: function(data) {
         $('#@bucketName-itemName').text(data.name);
         $('#@bucketName-itemKey').text(data.key);
-        $('#@bucketName-itemS3Url').text(data.s3Url).attr('href', data.s3Url);
         $('#@bucketName-itemCloudrontUrl').text(data.cloudfrontUrl).attr('href', data.cloudfrontUrl);
         $('#@bucketName-itemCreatedAt').text(data.creationDate);
         $('#@bucketName-itemCreatedBy').text(data.creator);
@@ -79,21 +75,12 @@
         $('#@bucketName-itemUploadAnotherVersion').attr('href', uploadUrl);
 
         $('#@bucketName-itemDetails').modal('show');
-        $('#@bucketName-itemS3Url').hide();
-        $('a.show-s3-url').show();
       },
       complete: function(xhr) {
         console.log(xhr)
       }
     })
 
-  });
-
-  $('a.show-s3-url').click(function(e){
-    e.preventDefault();
-
-    $('#@bucketName-itemS3Url').show();
-    $('a.show-s3-url').hide();
   });
 </script> 
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -117,7 +117,6 @@ amazon.s3.bucketCloudfrontMap = {}
 # Example:
 # (this particular example won't work as this bucket and distribution don't exist
 # amazon.s3.bucketCloudfrontMap.dev-cashy.cloudfront =  "http://d2zt0093sgpvii.cloudfront.net/"
-amazon.s3.fullAccessUrl = "https://s3.amazonaws.com/"
 amazon.s3.cdn.version = "1"
 amazon.s3.upload.timeout = 30
 amazon.s3.upload.cachetime = 2592000


### PR DESCRIPTION
This PR is a duplicate of a previously closed one (https://github.com/lucidsoftware/cashy/pull/49), and it does a few things

1. Requires s3 bucket configuration to provide access points to use for writing to the bucket
2. Removes the dead uploadTempFile method
3. Remove the "S3 URL" field for users to click to, since S3 objects aren't always public


From local testing, the S3 URL from the Asset Details popup is removed as expected
<img width="624" height="214" alt="image" src="https://github.com/user-attachments/assets/f96e94dc-689f-4904-a1ee-c7efbd09ef38" />

Here is what it used to look like:
<img width="624" height="214" alt="image" src="https://github.com/user-attachments/assets/e8e13e05-9df3-4dde-a71e-1c35ac08e4dd" />

The reason for the missing "Created By" and "Created At" information is because I'm running a clean-slate database locally that doesn't have that info to populate.

Since the "ETag", "Content-Type", "Content-Length", and "Cache-Control" headers are being returned, that means the SDK's "HeadObject" action is working correctly on the access point I have set